### PR TITLE
Better definition of data adaptor

### DIFF
--- a/backend/nexus-typegen.ts
+++ b/backend/nexus-typegen.ts
@@ -1,4 +1,4 @@
-import { LocationModel } from "./src/dataAccess/dataTypes" 
+import { LocationModel, RoomModel } from "./src/dataAccess/dataTypes" 
 
 import type { Context } from "./src/api/context"
 import type { core } from "nexus"

--- a/backend/src/api/context.ts
+++ b/backend/src/api/context.ts
@@ -1,21 +1,10 @@
-import { LocationDAO } from "../dataAccess/adaptors/prismaAdaptor/LocationDAO";
-import { ILocation, IRoom} from "../dataAccess/interfaces";
-import { RoomDAO } from "../dataAccess/adaptors/prismaAdaptor/RoomDAO";
+import { IDataAdaptor } from "../dataAccess/interfaces";
+import { PrismaDataAdaptor } from "../dataAccess/adaptors/prismaAdaptor/adaptor";
 
-type cleanAirDB = {
-    locationDAO: ILocation
-    roomDAO: IRoom
-}
 export interface Context {
-    db: cleanAirDB
+    db: IDataAdaptor
 }
-
-const locationDAO = new LocationDAO();
-const roomDAO = new RoomDAO();
 
 export const createContext =async () => ({
-    db: {
-        locationDAO: locationDAO,
-        roomDAO: roomDAO
-    }
+    db: new PrismaDataAdaptor()
 })

--- a/backend/src/api/schema.ts
+++ b/backend/src/api/schema.ts
@@ -13,7 +13,7 @@ export const schema = makeSchema({
     export: "Context",
   },
   sourceTypes: {
-    headers: [ 'import { LocationModel } from "./src/dataAccess/dataTypes" '],
+    headers: [ 'import { LocationModel, RoomModel } from "./src/dataAccess/dataTypes" '],
     modules: []
   }
 })

--- a/backend/src/dataAccess/IDataAdaptor.ts
+++ b/backend/src/dataAccess/IDataAdaptor.ts
@@ -1,0 +1,7 @@
+import { PrismaDataAdaptor } from "./adaptors/prismaAdaptor/adaptor";
+import { ILocation, IRoom } from "./interfaces";
+
+export interface IDataAdaptor {
+    locationDAO : ILocation
+    roomDAO : IRoom
+}

--- a/backend/src/dataAccess/adaptors/prismaAdaptor/LocationDAO.ts
+++ b/backend/src/dataAccess/adaptors/prismaAdaptor/LocationDAO.ts
@@ -3,7 +3,11 @@ import { ILocation } from '../../interfaces'
 import { LocationModel, RoomModel } from '../../dataTypes'
 
 export class LocationDAO implements ILocation {
-    client = new PrismaClient();
+    client : PrismaClient;
+
+    constructor(client : PrismaClient) {
+        this.client = client;
+    }
 
     getById(id: number) : Promise<LocationModel | null> {
         return this.client.location.findUnique({ where: { locationId: id}});

--- a/backend/src/dataAccess/adaptors/prismaAdaptor/RoomDAO.ts
+++ b/backend/src/dataAccess/adaptors/prismaAdaptor/RoomDAO.ts
@@ -3,8 +3,12 @@ import { IRoom } from '../../interfaces'
 import { RoomModel, LocationModel } from '../../dataTypes'
 
 export class RoomDAO implements IRoom {
-    client = new PrismaClient();
+    client : PrismaClient;
 
+    constructor(client : PrismaClient) {
+        this.client = client;
+    }
+    
     getById(id: number) : Promise<RoomModel | null> {
         return this.client.room.findUnique({ where: { roomId: id}});
     };

--- a/backend/src/dataAccess/adaptors/prismaAdaptor/adaptor.ts
+++ b/backend/src/dataAccess/adaptors/prismaAdaptor/adaptor.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@prisma/client";
+import { IDataAdaptor, ILocation, IRoom } from "../../interfaces";
+import { LocationDAO } from "./LocationDAO";
+import { RoomDAO } from "./RoomDAO";
+
+const prisma = new PrismaClient({
+    log: ['query', 'info', 'warn', 'error'],
+  })
+
+export class PrismaDataAdaptor implements IDataAdaptor {
+    client : PrismaClient
+    locationDAO: ILocation
+    roomDAO: IRoom
+
+    constructor() {
+        this.client = prisma
+        this.locationDAO = new LocationDAO(this.client)
+        this.roomDAO = new RoomDAO(this.client)
+    }
+}

--- a/backend/src/dataAccess/dataTypes.ts
+++ b/backend/src/dataAccess/dataTypes.ts
@@ -1,8 +1,3 @@
-export { User } from "@prisma/client"
-export { Reading } from "@prisma/client"
-export { Location } from "@prisma/client"
-export { Room } from "@prisma/client"
-
 // TODO: figure out if this can be referenced from Prisma types
 export interface LocationModel {
     locationId: number
@@ -29,5 +24,4 @@ export interface RoomModel {
     name: string
     created_id: number
     created_at: Date
-}
 }

--- a/backend/src/dataAccess/interfaces.ts
+++ b/backend/src/dataAccess/interfaces.ts
@@ -1,2 +1,3 @@
+export { IDataAdaptor } from './IDataAdaptor'
 export { ILocation } from './ILocation'
 export { IRoom } from './IRoom'


### PR DESCRIPTION
A data adaptor is an object that exposes a DAO for each of the model
types.
This should eventually allow for loading of different types of data
adaptors based on config

Bugfixes
- add room type to SourceTypes in Nexus Schema