### PR TITLE
Package Docker GraphQL server as Docker image in build workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [ "main", "refactor", "github-actions-sandbox" ]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+  SERVER_BUILD_ARTIFACT: server-build-dir
+  SERVER_BUILD_PATH: ./backend/dist
+
 jobs:
   build-client:
 
@@ -55,3 +61,46 @@ jobs:
       - run: npm install
       - run: npm ci
       - run: npm run build --if-present
+      -
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.SERVER_BUILD_ARTIFACT }}
+          path: ${{ env.SERVER_BUILD_PATH }}
+
+  build-and-deploy-server-image:
+    needs: build-server
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub packages
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}-be
+      -
+        uses: actions/checkout@v3
+      -
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.SERVER_BUILD_ARTIFACT }}
+          path: ${{ env.SERVER_BUILD_PATH }}
+      -
+        name: Build and push docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -25,9 +25,7 @@ services:
     restart: unless-stopped
 
   cleanair-be:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ${COMPOSE_BE_IMAGE_REGISTRY}/cleanairmap-be:${COMPOSE_BE_IMAGE_TAG:-latest}
     container_name: cleanair-be
     depends_on:
       - postgres

--- a/backend/env.sample
+++ b/backend/env.sample
@@ -7,3 +7,8 @@ DATABASE_PORT=5432
 PLAYGROUND_PORT=4000
 DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@localhost:${DATABASE_PORT}/postgres?schema=public
 # USE_LEGACY_ENDPOINT=set to point to graqphql endpoint.
+
+# This should be a reference to a tagged image deployed to the project's container registry
+#   This example is for the image build for a PR, with the image deployed to GitHub Packages
+COMPOSE_BE_IMAGE_TAG="pr-2"
+COMPOSE_BE_IMAGE_REGISTRY="ghcr.io/Makermed"


### PR DESCRIPTION
Creating Docker images for the backend on the main branches and on PRs should make it easier to review, and to test different versions without having to jump between branches as much